### PR TITLE
Fix the missing symbolic link directory for "libsel4sync"

### DIFF
--- a/3.2.x.xml
+++ b/3.2.x.xml
@@ -34,6 +34,7 @@
     <linkfile src="libsel4utils" dest="libs/libsel4utils"/>
     <linkfile src="libsel4vka" dest="libs/libsel4vka"/>
     <linkfile src="libsel4vspace" dest="libs/libsel4vspace"/>
+    <linkfile src="libsel4sync" dest="libs/libsel4vsync"/>
 </project>
 <project name="util_libs.git" path="projects/util_libs" revision="3.2.x-compatible">
     <linkfile src="libcpio" dest="libs/libcpio"/>


### PR DESCRIPTION
Following the instructions mentioned in [Getting Started](https://wiki.sel4.systems/Getting%20started):
```
mkdir seL4test
cd seL4test
repo init -u https://github.com/seL4/sel4test-manifest.git
repo sync
make ia32_simulator_release_xml_defconfig
``` 
the step "make ia32_simulator_release_xml_defconfig"  failed and compiained:
```
Kconfig:45: can't open file "libs/libsel4sync/Kconfig"
```

I noticed that it was just a missing symbolic link directory.