### PR TITLE
xml: Use OpenSBI instead of BBL

### DIFF
--- a/common.xml
+++ b/common.xml
@@ -24,6 +24,7 @@ fetch="."
 
 <remote fetch="../sel4proj" name="sel4proj"/>
 <remote fetch="https://github.com/nanopb" name="nanopb" />
+<remote fetch="https://github.com/riscv" name="opensbi"/>
 
 <default revision="master"
 remote="seL4"
@@ -41,7 +42,7 @@ remote="seL4"
     <linkfile src="easy-settings.cmake" dest="easy-settings.cmake"/>
 </project>
 <project name="sel4_projects_libs" path="projects/sel4_projects_libs" remote="sel4proj" />
-<project name="riscv-pk" remote="sel4proj" revision="fix-32bit" path="tools/riscv-pk"/>
+<project name="opensbi" remote="opensbi" revision="a98258d0b537a295f517bbc8d813007336731fa9" path="tools/opensbi"/>
 <project name="nanopb" path="tools/nanopb" revision="847ac296b50936a8b13d1434080cef8edeba621c" upstream="master" remote="nanopb"/>
 
 </manifest>

--- a/default.xml
+++ b/default.xml
@@ -12,6 +12,7 @@
 -->
 <manifest>
   <remote fetch="https://github.com/nanopb" name="nanopb"/>
+  <remote fetch="https://github.com/riscv" name="opensbi"/>
   <remote fetch="." name="seL4"/>
   <remote fetch="../sel4proj" name="sel4proj"/>
   
@@ -19,7 +20,7 @@
   
   <project dest-branch="sel4" name="musllibc.git" path="projects/musllibc" revision="4a8335b2248d934e2e40386af4f1b0495b3c173d" upstream="sel4"/>
   <project name="nanopb" path="tools/nanopb" remote="nanopb" revision="847ac296b50936a8b13d1434080cef8edeba621c" upstream="master"/>
-  <project dest-branch="fix-32bit" name="riscv-pk" path="tools/riscv-pk" remote="sel4proj" revision="d3293c7c23e923338318f3860b2f20dd0b51a016" upstream="fix-32bit"/>
+  <project name="opensbi" path="tools/opensbi" remote="opensbi" revision="a98258d0b537a295f517bbc8d813007336731fa9" upstream="master"/>
   <project dest-branch="master" name="seL4.git" path="kernel" revision="b86bce2d4b11f9c4c5cd66c40eb47900bf51eaae" upstream="master"/>
   <project dest-branch="master" name="seL4_libs.git" path="projects/seL4_libs" revision="70dd9243456da78d030fa13af6642ba080b703a2" upstream="master"/>
   <project dest-branch="master" name="seL4_tools.git" path="tools/seL4" revision="ffe3305d8d3926ccfa0fa8019063c786b75850d6" upstream="master">


### PR DESCRIPTION
This is part of a collection of PRs to convert from using the legacy BBL and riscv-pk to OpenSBI.

Other PRs include:
* https://github.com/seL4/seL4/pull/272
* https://github.com/seL4/sel4test/pull/28
* https://github.com/seL4/seL4_tools/pull/46
* https://github.com/seL4/sel4test-manifest/pull/7

Signed-off-by: Alistair Francis <alistair.francis@wdc.com>