### PR TITLE
update OpenSBI to v0.9

### DIFF
--- a/common.xml
+++ b/common.xml
@@ -36,7 +36,7 @@ remote="seL4"
     <linkfile src="easy-settings.cmake" dest="easy-settings.cmake"/>
 </project>
 <project name="sel4_projects_libs" path="projects/sel4_projects_libs" />
-<project name="opensbi" remote="opensbi" revision="refs/tags/v0.8" path="tools/opensbi"/>
+<project name="opensbi" remote="opensbi" revision="refs/tags/v0.9" path="tools/opensbi"/>
 <project name="nanopb" path="tools/nanopb" revision="refs/tags/0.4.3" upstream="master" remote="nanopb"/>
 
 </manifest>


### PR DESCRIPTION
We should move OpenSBI from v0.8 to v0.9 to stay aligned with the development there. What (else) would be needed to make this step actually? it this change enough?
- https://github.com/seL4/camkes-manifest/blob/master/default.xml is already at the commit that is v0.9, but using `refs/tags/v0.9` in https://github.com/seL4/camkes-manifest/blob/master/master.xml seems cleaner to me thant using the raw commit id. 
- https://github.com/seL4/sel4bench-manifest/blob/master/master.xml is at v0.9 and need this update also
- https://github.com/seL4/mcs-examples-manifest/blob/master/master.xml is still using `riscv-pk`, so I assume this is not actively maintained currently. 
