### PR TITLE
update OpenSBI to v1.2

### DIFF
--- a/common.xml
+++ b/common.xml
@@ -36,7 +36,7 @@ remote="seL4"
     <linkfile src="easy-settings.cmake" dest="easy-settings.cmake"/>
 </project>
 <project name="sel4_projects_libs" path="projects/sel4_projects_libs" />
-<project name="opensbi" remote="opensbi" revision="refs/tags/v1.1" path="tools/opensbi"/>
+<project name="opensbi" remote="opensbi" revision="refs/tags/v1.2" path="tools/opensbi"/>
 <project name="nanopb" path="tools/nanopb" revision="refs/tags/0.4.3" upstream="master" remote="nanopb"/>
 
 </manifest>

--- a/common.xml
+++ b/common.xml
@@ -36,7 +36,7 @@ remote="seL4"
     <linkfile src="easy-settings.cmake" dest="easy-settings.cmake"/>
 </project>
 <project name="sel4_projects_libs" path="projects/sel4_projects_libs" />
-<project name="opensbi" remote="opensbi" revision="refs/tags/v1.0" path="tools/opensbi"/>
+<project name="opensbi" remote="opensbi" revision="refs/tags/v1.1" path="tools/opensbi"/>
 <project name="nanopb" path="tools/nanopb" revision="refs/tags/0.4.3" upstream="master" remote="nanopb"/>
 
 </manifest>

--- a/common.xml
+++ b/common.xml
@@ -36,7 +36,7 @@ remote="seL4"
     <linkfile src="easy-settings.cmake" dest="easy-settings.cmake"/>
 </project>
 <project name="sel4_projects_libs" path="projects/sel4_projects_libs" />
-<project name="opensbi" remote="opensbi" revision="refs/tags/v0.9" path="tools/opensbi"/>
+<project name="opensbi" remote="opensbi" revision="refs/tags/v1.0" path="tools/opensbi"/>
 <project name="nanopb" path="tools/nanopb" revision="refs/tags/0.4.3" upstream="master" remote="nanopb"/>
 
 </manifest>


### PR DESCRIPTION
v1.2 is the latest released version. Support for JH71110 was added afterwards unfortunately, trying to find out what the 1.3 release plans are.

Test with: axel-h/opensbi#1