### PR TITLE
README: less generic blurb

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,12 @@
 
 sel4test-manifest
 =================
-The sel4test project aims to test sel4 and some of its user libraries on many different targets.
 
-For general instructions on using this repository, see [Getting Started](https://docs.sel4.systems/GettingStarted)
-and the [seL4Test page](https://docs.sel4.systems/seL4Test) on the docsite.
+The `sel4test` project aims to test the seL4 kernel and some of its user libraries on many different
+targets.
 
-See [Host Dependencies](https://docs.sel4.systems/HostDependencies) for required dependencies.
+For instructions on using this repository, see the [seL4Test
+page](https://docs.sel4.systems/seL4Test) on the [seL4 docsite](https://docs.sel4.systems).
+
+See [Host Dependencies](https://docs.sel4.systems/HostDependencies) for required toolchains and
+dependencies to build `sel4test`.


### PR DESCRIPTION
Tweak text to make it more specific and remove GettingStarted link.

The previous text was mostly generic pointing to docsite pages (GettingStarted) that are not actually helpful for what was claimed in the text.