### PR TITLE
Bump nanobp version

### DIFF
--- a/common.xml
+++ b/common.xml
@@ -37,6 +37,6 @@ remote="seL4"
 </project>
 <project name="sel4_projects_libs" path="projects/sel4_projects_libs" />
 <project name="opensbi" remote="opensbi" revision="refs/tags/v0.9" path="tools/opensbi"/>
-<project name="nanopb" path="tools/nanopb" revision="refs/tags/0.4.3" upstream="master" remote="nanopb"/>
+<project name="nanopb" path="tools/nanopb" revision="refs/tags/0.4.9.1" upstream="master" remote="nanopb"/>
 
 </manifest>


### PR DESCRIPTION
Recent (3.13) python versions fail on older nanobp's use of pkg_resources. nanobp 0.4.9.0 fixes that problem. 0.4.9.1 is a bugfix release over that and the current most recent version.

Test with: https://github.com/seL4/seL4_tools/pull/255

